### PR TITLE
Замена протокола api с http на https 

### DIFF
--- a/Views/Scripts.fs
+++ b/Views/Scripts.fs
@@ -68,7 +68,7 @@ let private src = """
                 };
 
                 const program = window.editor.getValue();
-                const url = 'http://rextester.com/rundotnet/api';
+                const url = 'https://rextester.com/rundotnet/api';
                 const fsharp = 3; // in rextester encoding
                 const params = {
                     LanguageChoice: fsharp,


### PR DESCRIPTION
На главной странице перестало работать окошко с онлайн-компилятором из-за изменения протокола передачи данных у 
https://rextester.com
В пулл реквесте у адреса заменен протокол с http на https.

PS:
Судя по всему проблема в ишуе #10  именно из-за этого.
